### PR TITLE
Adds retention comment and url

### DIFF
--- a/MassApplyRetentionPolicyO365.ps1
+++ b/MassApplyRetentionPolicyO365.ps1
@@ -13,5 +13,8 @@ Import-Module $((Get-ChildItem -Path $($env:LOCALAPPDATA+"\Apps\2.0\") -Filter M
 $EXOSession = New-ExoPSSession
 Import-PSSession $EXOSession
 
+$retentionPolicy = "Standard"
+$retentionComment = "Standard Retention Policy  - 90-day delete"
+$retentionURL = "https://support.youdomain.com/policies/retention/standard.html"
 
-$UserMailboxes = Get-Mailbox -Filter {(RecipientTypeDetails -eq 'UserMailbox')} $UserMailboxes | Set-Mailbox –RetentionPolicy <Policy name>
+$UserMailboxes = Get-Mailbox -Filter {(RecipientTypeDetails -eq 'UserMailbox')} $UserMailboxes | Set-Mailbox –RetentionPolicy $retentionPolicy -RetentionComment $retentionComment -RetentionURL $retentionURL


### PR DESCRIPTION
The retentionComment parameter allows administrators to let users know what policies apply to them and the retentionURL parameter provides a URL to users to learn more about the policy applied to their mailbox. Both of these are exposed to the user in the 'backstage' area of Outlook.